### PR TITLE
fix number of updates for actor and critic_target networks

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -128,10 +128,12 @@ def main(args):
 				action = agent.sample_action(obs)
 
 		# Run training update
-		if step >= args.init_steps:
-			num_updates = args.init_steps if step == args.init_steps else 1
-			for _ in range(num_updates):
-				agent.update(replay_buffer, L, step)
+		if step == args.init_steps:
+			for i in range(1, args.init_steps + 1):
+				agent.update(replay_buffer, L, i)
+
+		if step > args.init_steps:
+			agent.update(replay_buffer, L, step)
 
 		# Take step
 		next_obs, reward, done, _ = env.step(action)


### PR DESCRIPTION
The number of updates to the actor network, SAC's alpha value, and critic_target networks was too many (with default arg values) during the for-loop when step == args.init_steps. This is because "step" was given as an argument to the agent.update() function, instead of the index of the for loop. This argument is used on line 147 and 150 of SAC: https://github.com/nicklashansen/dmcontrol-generalization-benchmark/blob/a81df68838757ca55c19ac5f9fd8cd04bf8a942c/src/algorithms/sac.py#L147C1-L147C1

Depending on the value of args.init_steps and args.actor_update_freq this means that the actor network was either updated 0 times or args.init_steps times. (For default args values: the actor network was updated 1000 times, while it should only be updated 500 times, as args.actor_update_freq==2)